### PR TITLE
Pin serverless framework to version 3

### DIFF
--- a/index.js
+++ b/index.js
@@ -12,7 +12,7 @@ var DOMAIN_MANAGER = core.getInput('domain-manager')
 async function installServerlessAndPlugins() {
   await exeq(
     `echo Installing Serverless and plugins...`,
-    `npm i serverless -g`,
+    `npm i serverless@3.26.0 -g`,
     `npm i serverless-plugin-canary-deployments`,
     `npm i serverless-python-requirements`
   )


### PR DESCRIPTION
Version 4 requires a paid account which caused our deployments to fail